### PR TITLE
fix fstring

### DIFF
--- a/klayout/python/metaports/ports.py
+++ b/klayout/python/metaports/ports.py
@@ -156,9 +156,9 @@ def portdict_from_meta(cell):
 def show_port(port, cell, layout):  
     
     if "cross_section" in port:
-        cs = layout.meta_info_value(f"kfactory:cross_section:{port["cross_section"]}")
+        cs = layout.meta_info_value(f"kfactory:cross_section:{port['cross_section']}")
         port["width"] = cs["width"]
-        port["layer"] = layout.meta_info_value(f"kfactory:layer_enclosure:{cs["layer_enclosure"]}")["main_layer"]
+        port["layer"] = layout.meta_info_value(f"kfactory:layer_enclosure:{cs['layer_enclosure']}")["main_layer"]
     if "width" in port and "layer" in port and "trans" in port:
         lidx = cell.layout().layer(port["layer"])
         trans = pya.Trans(port["trans"])


### PR DESCRIPTION
fixes https://github.com/gdsfactory/gdsfactory/issues/3317

- Correct f-string syntax in the show_port function to use single quotes for dictionary keys so that it works for python < 3.12